### PR TITLE
Update FreeDesktop runtime from 23.08 to 24.08

### DIFF
--- a/com.invoiceninja.InvoiceNinja.yml
+++ b/com.invoiceninja.InvoiceNinja.yml
@@ -3,7 +3,7 @@
 ---
 app-id: com.invoiceninja.InvoiceNinja
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 command: invoiceninja
 separate-locales: false


### PR DESCRIPTION
[FreeDesktop 23.08 runtime is EOL](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/wikis/Releases) resulting in

<img width="570" height="93" alt="image" src="https://github.com/user-attachments/assets/f3d5f563-0ec4-406d-927a-b342ef7de812" />

Updated runtime.